### PR TITLE
gapps: Fix inline compiling for SetupWizard

### DIFF
--- a/common/Android.mk
+++ b/common/Android.mk
@@ -151,6 +151,7 @@ LOCAL_MODULE := SetupWizard
 LOCAL_MODULE_OWNER := gapps
 LOCAL_SRC_FILES := proprietary/priv-app/SetupWizard/SetupWizard.apk
 LOCAL_CERTIFICATE := PRESIGNED
+LOCAL_OVERRIDES_PACKAGES := Provision
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := APPS
 LOCAL_DEX_PREOPT := false


### PR DESCRIPTION
Override Provision package, else SetupWizard won't get it's permissions
 properly granted.

TODO: Nuke Provision on mindthegapps installation via sideload