### PR TITLE
gapps: Allow SetupWizard REQUEST_NETWORK_SCORES permission

### DIFF
--- a/common/proprietary/etc/permissions/privapp-permissions-google.xml
+++ b/common/proprietary/etc/permissions/privapp-permissions-google.xml
@@ -339,6 +339,7 @@ It allows additional grants on top of privapp-permissions-platform.xml
         <permission name="android.permission.OVERRIDE_WIFI_CONFIG"/>
         <permission name="android.permission.PERFORM_CDMA_PROVISIONING"/>
         <permission name="android.permission.READ_PRIVILEGED_PHONE_STATE"/>
+        <permission name="android.permission.REQUEST_NETWORK_SCORES"/>
         <permission name="android.permission.REBOOT"/>
         <permission name="android.permission.SET_TIME"/>
         <permission name="android.permission.SET_TIME_ZONE"/>


### PR DESCRIPTION
   * without this, setup wizard will constantly crash after granting location
     permission.