### PR TITLE
updater-binary: Revert "Install to opposite slot" logic

### DIFF
--- a/build/meta/com/google/android/update-binary
+++ b/build/meta/com/google/android/update-binary
@@ -40,9 +40,9 @@ if [ "$SYSTEMASROOT" == "true" ]; then
   CURRENTSLOT=`getprop ro.boot.slot_suffix`
   if [ ! -z "$CURRENTSLOT" ]; then
     if [ "$CURRENTSLOT" == "_a" ]; then
-      TARGETSYSTEM=/dev/block/bootdevice/by-name/system_b
-    else
       TARGETSYSTEM=/dev/block/bootdevice/by-name/system_a
+    else
+      TARGETSYSTEM=/dev/block/bootdevice/by-name/system_b
     fi
   else
     TARGETSYSTEM=/dev/block/bootdevice/by-name/system


### PR DESCRIPTION
* Currently, on both devices enforcing veirty, and devices not
  enforcing verity, we are unable to flash files to the system
  partition after a payload (a/b) style flash. Revert this
  logic until if/when we figure this out.

* A/B users will need to flash the ROM, reboot, and install
  from thee recovery in the other slot.