### PR TITLE
gapps: Add AndroidMigratePrebuilt

### DIFF
--- a/build/meta/com/google/android/update-binary
+++ b/build/meta/com/google/android/update-binary
@@ -85,6 +85,7 @@ cd system
 
 if [ "$MEM" -lt "$LOWMEM" ]; then
   ui_print "Low RAM device detected, removing large extras"
+  exec_util "rm -rf priv-app/AndroidMigratePrebuilt"
   exec_util "rm -rf priv-app/SetupWizard"
   exec_util "rm -rf priv-app/Velvet"
 fi

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -168,6 +168,18 @@ include $(BUILD_PREBUILT)
 
 ifeq ($(TARGET_IS_GROUPER),)
 include $(CLEAR_VARS)
+LOCAL_MODULE := AndroidMigratePrebuilt
+LOCAL_MODULE_OWNER := gapps
+LOCAL_SRC_FILES := proprietary/priv-app/AndroidMigratePrebuilt/AndroidMigratePrebuilt.apk
+LOCAL_CERTIFICATE := PRESIGNED
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := APPS
+LOCAL_DEX_PREOPT := false
+LOCAL_MODULE_SUFFIX := .apk
+LOCAL_PRIVILEGED_MODULE := true
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := SetupWizard
 LOCAL_MODULE_OWNER := gapps
 LOCAL_SRC_FILES := proprietary/priv-app/SetupWizard/SetupWizard.apk

--- a/common/common-vendor.mk
+++ b/common/common-vendor.mk
@@ -38,5 +38,6 @@ PRODUCT_PACKAGES += \
 ifeq ($(TARGET_IS_GROUPER),)
 
 PRODUCT_PACKAGES += \
+    AndroidMigratePrebuilt \
     SetupWizard
 endif

--- a/proprietary-files-common-nongrouper.txt
+++ b/proprietary-files-common-nongrouper.txt
@@ -1,1 +1,2 @@
+-priv-app/AndroidMigratePrebuilt/AndroidMigratePrebuilt.apk;PRESIGNED
 -priv-app/SetupWizard/SetupWizard.apk;PRESIGNED


### PR DESCRIPTION
* On Custom ROM's on Pixels, the downloading of
  this app by SetupWizard often hangs up,
  and needs to be restarted. Ship this to avoid
  that.

* Added to LOWMEM checkas it isn't necessary.