### PR TITLE
Remove Provision only if installing SetupWizard

### DIFF
--- a/build/meta/com/google/android/update-binary
+++ b/build/meta/com/google/android/update-binary
@@ -129,7 +129,9 @@ for dirs in $DIRS; do
 done
 ui_print "Copying files"
 exec_util "cp --preserve=a -r ./* /system/"
-exec_util "rm -rf /system/priv-app/Provision/"
+if [ -e priv-app/SetupWizard ] ; then
+    exec_util "rm -rf /system/priv-app/Provision/"
+fi
 ui_print "Cleaning up files"
 cd ../
 exec_util "rm -rf system/"


### PR DESCRIPTION
On devices with low memory or storage, the update-binary skips
installation of SetupWizard, which normally overrides AOSP's Provision
app. Unfortunately, the script currently removes the Provision app even
when SetupWizard is not installed in the low memory or storage case,
which causes the device to remain stuck in an unprovisioned state (Home
button doesn't work for example).

Tests
-----

Tested on Nexus 5 (hammerhead) with LOW_STORAGE and confirmed that the
Provision app is not removed since SetupWizard is not installed.
Confirmed that the Play store works.

Tested on Nexus 5X (bullhead) which is not LOW_STORAGE and confirmed
that the Provision app is removed since SetupWizard is installed.
Confirmed that the Play store works.